### PR TITLE
Started standards chapter

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -28,6 +28,7 @@ book:
     - wdlconfig.qmd
     - docker.qmd
     - conventions.qmd
+    - standards.qmd
   site-url: https://getwilds.org/guide/
 
 bibliography: references.bib

--- a/docker.qmd
+++ b/docker.qmd
@@ -3,7 +3,7 @@
 
 The mindset with regard to Docker images is different for WILDS WDLs compared to other projects. Normally, repositories are relatively self-contained and only need one image that can just be directly linked to that repository. However, WDL pipelines often require a different image for each step, creating the need for a laundry list of Docker images for each repository. In addition, our bioinformatics workflows will have a large amount of image overlap in that the same tools get used, just in a different fashion depending on the workflow. To avoid unnecessary image duplication, the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) will contain all Dockerfiles and images relevant to WILDS and all future workflows refer back to these images.
 
-## Docker Image Guidelines
+## Docker Image Guidelines {#sec-docker-image}
 
 - Because these Docker images will be used for individual steps within WDL workflows, they should be as minimal as possible in terms of the number of tools installed in each image (1 or 2 max).
 - As a general (but flexible) rule, try to start from as basic of a [parent image](https://github.com/getwilds/wilds-docker-library/blob/5b5aa0d936ad71267002c7df64638a16dcea02dc/samtools/Dockerfile_latest#L3) as possible, e.g. `scratch`, `ubuntu`, `python`, `r-base`, etc.
@@ -12,7 +12,7 @@ The mindset with regard to Docker images is different for WILDS WDLs compared to
     - For this reason, reference data should not be stored in an image unless absolutely necessary.
     - Unnecessary tools should also be avoided, even if they serve a "just-in-case" functionality.
 
-## Dockerfile Guidelines
+## Dockerfile Guidelines {#sec-dockerfile}
 - Every Dockerfile must contain the [labels below](https://github.com/getwilds/wilds-docker-library/blob/5b5aa0d936ad71267002c7df64638a16dcea02dc/bwa/Dockerfile_0.7.17#L6C1-L13C44) at a minimum. This provides users with increased visibility in terms of where the image came from and open access to the necessary resources in case they have any questions or concerns.
 ```
 LABEL org.opencontainers.image.title="awesomeimage" # Name of the image in question
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.licenses=MIT # License type for the image in ques
     - If you just specify "latest", a tag that get updated frequently over time, your image could be completely different the next time you build it, even though it uses the exact same Dockerfile.
     - On the other hand, specifying "v1.2.3" will always pull the same instance of the tool every time, providing greater reproducibility over time.
 
-## Repository Guidelines
+## Repository Guidelines {#sec-docker-repo}
 
 - In terms of the repo organization, each image should have its own directory named after the tool being used in the image. Each version of the image should have its own Dockerfile in that directory following the naming convention of `[IMAGENAME]/Dockerfile_[VERSIONTAG]`.
     - If formatted correctly, a GitHub Action will [automatically build and upload](https://github.com/getwilds/wilds-docker-library/blob/main/.github/workflows/docker-images.yml) the image to the [WILDS GitHub container registry](https://github.com/orgs/getwilds/packages) upon merging into the `main` branch.

--- a/maintenance.qmd
+++ b/maintenance.qmd
@@ -12,7 +12,7 @@ All software (R, Python, etc.) in the WILDS should by default use the [MIT licen
 
 If there are circumstances which prevent using MIT, please do discuss with Sean or Scott.
 
-### R
+### R {#sec-license-r}
 
 In R, you can add the MIT license to your repository with the following code:
 
@@ -25,12 +25,12 @@ usethis::use_mit_license()
 
 Note that `usethis::use_mit_license` adds two files to your repository (`LICENSE` and `LICENSE.md`, and adds entries to the `.Rbuildignore` file so that `R CMD CHECK` doesn't complain).
 
-### Python
+### Python {#sec-license-python}
 
 There's no widely accepted single tool for dealing with licenses in Python similar to the above for R. For Python packages, simply include the license type (e.g., `MIT`) in your setup.py, setup.cfg, pyproject.toml, etc., and include the text of the license in a `LICENSE` file in the root of your repository.
 
 
-## Package versioning
+## Package versioning {#sec-versioning}
 
 There is a detailed discussion of versioning R packages in the [lifecycle][] chapter of the [R Packages book][rpkgs] by Hadley Wickham and Jenny Bryan. Please follow that chapter in general for versioning of R and Python packages within the WILDS. To make it easier to grok, below are some of the highlights, and some exceptions to that chapter.
 
@@ -58,7 +58,7 @@ Following the [Tidyverse package version conventions](https://r-pkgs.org/lifecyc
 
 We are not following or enforcing any rules about changes at the function/class/etc level below the package level. For example, the R Packages book [talks about][funcx] using the `lifecycle` package to deal with function changes.
 
-## Package releases
+## Package releases {#sec-releases}
 
 In general follow the [Releasing to CRAN chapter](https://r-pkgs.org/release.html) in the book [R Packages][rpkgs] for R, and the [Releasing and versioning chapter](https://py-pkgs.org/07-releasing-versioning) in the book [Python Packages][pypkgs] for Python. Those chapters don't have to be followed to the letter, but in general they provide really good guidance.
 

--- a/maintenance.qmd
+++ b/maintenance.qmd
@@ -29,6 +29,16 @@ Note that `usethis::use_mit_license` adds two files to your repository (`LICENSE
 
 There's no widely accepted single tool for dealing with licenses in Python similar to the above for R. For Python packages, simply include the license type (e.g., `MIT`) in your setup.py, setup.cfg, pyproject.toml, etc., and include the text of the license in a `LICENSE` file in the root of your repository.
 
+### WDL {#sec-license-wdl}
+
+Similarly, there is currently no universal standard for incorporating licenses within WDL packages. We recommend stating the license type in a comment at the top of the workflow script, and including the text of the license in a `LICENSE` file in the root of your repository.
+
+### Docker {#sec-license-docker}
+
+License type can be specified within the corresponding Dockerfile of each container using the "license" label: 
+```
+LABEL org.opencontainers.image.licenses=MIT
+```
 
 ## Package versioning {#sec-versioning}
 

--- a/packagedocs.qmd
+++ b/packagedocs.qmd
@@ -2,7 +2,7 @@
 
 All formally supported WILDS R and Python packages should have package documentation.
 
-## R
+## R {#sec-docs-r}
 
 We use the [pkgdown][] package to create documentation for R packages, and host it on [GitHub Pages][ghpages]. To get started with `pkgdown`, in R within the root of your package run [usethis::use_pkgdown_github_pages()](https://usethis.r-lib.org/reference/use_pkgdown.html) - it will set up a `_pkgdown.yml` file in the root of your repo used to configure `pkgdown`, and add a `.github/workflows/publish.yml` file to build the package documentation on each push, pull request, or release. See [pkgdown documentation][pkgdown] for details on configuring documentation.
 
@@ -21,7 +21,7 @@ template:
 
 For now just use the default theme that `pkgdown` provides.
 
-## Python
+## Python {#sec-docs-python}
 
 Just like there's a variety of ways to do packing in Python there's a variety of documentation options. Two of the well known options are:
 

--- a/standards.qmd
+++ b/standards.qmd
@@ -30,7 +30,12 @@ Each Python package in WILDS should follow the following standards:
 
 ## Docker
 
-Coming soon!
+Each Docker container in WILDS should follow the following standards:
+
+- Maintain necessary [labels](https://docs.docker.com/reference/dockerfile/#label) within the Dockerfile (see @sec-dockerfile)
+- Use an open source license; in most cases that means MIT (see @sec-license-docker)
+- Keep containers as minimal and specific as possible (see @sec-docker-image)
+- Follow all conventions in @sec-docker
 
 ## Research Compendia
 
@@ -38,7 +43,12 @@ Coming soon!
 
 ## WDL
 
-Coming soon!
+Each WDL workflow in WILDS should follow the following standards:
+
+- Maintain package documentation in the README of the repository at a minimum
+- Use an open source license; in most cases that means MIT (see @sec-license-wdl)
+- Follow our package versioning guidelines (see @sec-versioning)
+- Follow all conventions in @sec-wdlconfig
 
 ## NextFlow
 

--- a/standards.qmd
+++ b/standards.qmd
@@ -1,0 +1,50 @@
+# Standards {{< iconify fa6-solid scale-balanced >}} {#sec-standards}
+
+::: {.callout-note}
+These are living standards. Have a question/concern/suggestion? [Let's chat](https://github.com/getwilds/guide/issues/new).
+:::
+
+Standards for each repository type ...
+
+In order to keep the standards easily digestable, for each repo type below we keep each standard short and simple and link out to other sections of the book for more information.
+
+## R
+
+Each R package in WILDS should follow the following standards:
+
+- Use package `pkgdown` to create package documentation (see @sec-docs-r)
+- Use an open source license; in most cases that means MIT (see @sec-license-r)
+- Follow our package versioning guidelines (see @sec-versioning)
+- Follow our package releases guidelines (see @sec-releases)
+- Follow all conventions in @sec-conventions
+
+## Python
+
+Each Python package in WILDS should follow the following standards:
+
+- Maintain package documentation (see @sec-docs-python)
+- Use an open source license; in most cases that means MIT (see @sec-license-python)
+- Follow our package versioning guidelines (see @sec-versioning)
+- Follow our package releases guidelines (see @sec-releases)
+- Follow all conventions in @sec-conventions
+
+## Docker
+
+Coming soon!
+
+## Research Compendia
+
+Coming soon!
+
+## WDL
+
+Coming soon!
+
+## NextFlow
+
+Coming soon!
+
+## Compliance with standards
+
+We're not sure how this will be done exactly. For now, we'll do compliance manually. Ideally the end state will be completely automated.
+

--- a/style.qmd
+++ b/style.qmd
@@ -29,7 +29,7 @@ See the [R languageserver][languageserver] GitHub repository for more informatio
 
 In the [getwilds/makefiles repo](https://github.com/getwilds/makefiles) we have an R package Makefile template with [three make targets](https://github.com/getwilds/makefiles/blob/main/R/Makefile#L31-L40) for styling package code: `lint_package`, `style_file`, and `style_package`. With that Makefile in the root of your package you can run `lint_package` to check for any problems, and run `style_file` or `style_package` to fix any problems. You can also just run the R code in those make targets in a terminal or within R.
 
-### GitHub Actions
+### GitHub Actions {#sec-style-actions}
 
 To get setup with GitHub Actions and `lintr` and `styler`, first install `lintr` if you don't have it:
 


### PR DESCRIPTION
#29 

some notes:

- Just R and Python for now
- I'm not sure i'm happy with the list of items in R and Python. The last one in each just points to another chapter and says follow all of those. perhaps we have a human readable list in this chapter and then a checklist somewhere - perhaps we could adapt the usethis pkg to make a checklist automatically in an issue in the maitnainer's repo with the items to follow
- added section at bottom of chapter "Compliance with standards", I think we do need automation to make this work, though i'm not sure how yet. i'm asking around the web to see what works for folks 