### PR TITLE
Incorporate SDLC best practices content

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -24,6 +24,7 @@ book:
         - codereview-general.qmd
         - codereview-guidelines.qmd
     - packagedocs.qmd
+    - testing.qmd
     - maintenance.qmd
     - wdlconfig.qmd
     - docker.qmd

--- a/codereview-dasl.qmd
+++ b/codereview-dasl.qmd
@@ -4,13 +4,20 @@
 
 At a high level we use the following approach:
 
-- Code review whenever possible - review is generally not required for every code change
+<!-- Code review whenever possible - review is generally not required for every code change
   - As a team grows, add in more code review
-  - Some projects in the WILDS may have changess pushed directly to main, while others may follow a pull request only approach
-- Follow our code review guidelines (@sec-review-guidelines)
+  - Some projects in the WILDS may have changess pushed directly to main, while others may follow a pull request only approach -->
+
+- Follow our code review guidelines (@sec-review-guidelines). Other great resources for code review:
+  - [Google’s Code Review Practices](https://google.github.io/eng-practices/)
+  - [Respectful Changes](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/cl_respect.md)
+  - [Respectful Code Reviews](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/cr_respect.md)
 - Testing must be used
   - With a small team testing is crucial to ensuring software does what it is expected to do, AND facilitates code changes in the future
   - When making a code contribution, make sure it is covered by existing tests, or write a new test if not
+- Code should not make it into the codebase without being reviewed, no matter the project status.
+- For projects with [**Experimental**](#statuses) status and above, the only way code should make it into the codebase is via pull request, with a review from at least one of the project leads.
+- All [**Stable**](#statuses) projects need branch protection on the `main` branch so that the `main` branch can only be updated via pull requests from `dev` or `hotfix-` branches with the approval of a project lead.
 - Automate the boring work / Have bots tell us to follow our own rules
   - Styling
   - Linting
@@ -44,7 +51,7 @@ External contributions may be one-off drive by contributions from someone that m
 
 ## What else?
 
-::: {.callout-warning}
+::: {.callout-note}
 What else should we cover in this chapter?
 :::
 

--- a/conventions.qmd
+++ b/conventions.qmd
@@ -44,7 +44,25 @@ WILDS projects will use badges to indicate their status. Badges are a widely use
 
 WILDS badges are maintained in a GitHub repository at <https://github.com/getwilds/badges>. There's a website for these badges and an easy click to copy interface at <https://getwilds.org/badges/>.
 
-An example badge: [![](https://getwilds.org/badges/badges/stable.svg)](https://getwilds.org/badges/#stable)
+Each status has a set of corresponding practices with respect to the following (which you can find throughout this book):
+
+- Versioning
+- Branching
+- Code Review
+- Testing
+- Documentation
+- Releases
+
+<!-- An example badge: [![](https://getwilds.org/badges/badges/stable.svg)](https://getwilds.org/badges/#stable) -->
+
+#### Statuses
+
+- **Concept** [![](https://getwilds.org/badges/badges/concept.svg)](https://getwilds.org/badges/#concept) Not useable, no support, not open to feedback, unstable API.
+- **Experimental** [![](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental) Useable, some support, not open to feedback, unstable API.
+- **Prototype** [![](https://getwilds.org/badges/badges/prototype.svg)](https://getwilds.org/badges/#prototype) Useable, some support, open to feedback, unstable API.
+- **Stable** [![](https://getwilds.org/badges/badges/stable.svg)](https://getwilds.org/badges/#stable) Useable, full support, open to feedback, stable API.
+- **Deprecated** [![](https://getwilds.org/badges/badges/deprecated.svg)](https://getwilds.org/badges/#deprecated) Useable as of a fixed, past date, no support, not open to feedback, stable API as of a fixed, past date.
+
 
 ### Contributing instructions
 

--- a/maintenance.qmd
+++ b/maintenance.qmd
@@ -55,7 +55,21 @@ package_version("2.0") > package_version("10.0")
 
 With that example, please do think about your package versions before setting them.
 
-#### WILDS Conventions
+### WILDS Conventions
+
+All of the software development work we do is versioned at every status.
+
+In general we try to follow the principles of [Semantic Versioning 2.0.0](https://semver.org/):
+
+- All software starts as version 0.1.0.
+- Bug fixes and hotfixes cause the patch number to increment: 0.1.0 → 0.1.1
+- Adding backwards compatible functionality causes the minor number to increment: 0.1.0 → 0.2.0
+- Adding non-backwards compatible functionality causes the major number to increment: 0.1.0 → 1.0.0
+- Minor number incrementation resets the patch number to zero: 0.1.3 → 0.2.0
+- Major number incrementation resets the minor and patch numbers to zero: 2.4.16 → 3.0.0
+- Developmental/incremental/fix/hotfix versions of software end with a fourth number starting with 9000. For example: 0.1.0.9000. The purpose of this number is that it can be incremented rapidly during the development process. For example, an individual working on a branch might increment the version from 0.1.0.9050 to 0.1.0.9061 over the course of multiple commits. This fourth number should be removed whenever we merge from `dev` to `main` (see the [Branching](#branching) section).
+
+Note that project status and version numbers are unrelated.
 
 Following the [Tidyverse package version conventions](https://r-pkgs.org/lifecycle.html#sec-lifecycle-version-number-tidyverse), WILDS packages will use the following conventions (see the link for more details):
 
@@ -68,16 +82,47 @@ Following the [Tidyverse package version conventions](https://r-pkgs.org/lifecyc
 
 We are not following or enforcing any rules about changes at the function/class/etc level below the package level. For example, the R Packages book [talks about][funcx] using the `lifecycle` package to deal with function changes.
 
+## Branching
+
+Overall the branching lifecycle can be summed up by the following:
+
+1. Make sure your local `dev` branch is up to date with the remote `dev` branch. When you want to add new content to a repository, you create a new branch from the `dev` branch.
+2. Make changes to that branch, then open a pull request against the `dev` branch.
+3. Once the contributions are reviewed and you get approval from a project lead, your pull request will be merged into the `dev` branch.
+4. Whenever project leads want to create a new release, they merge the `dev` branch into the `main` branch and tag a new release.
+5. Urgent fixes to the `main` branch can be made by creating a branch from `main` that begins with the hotfix- prefix, which is then merged directly into `main` via pull request and code review. The `dev` branch will then be updated to reflect the changes on `main` via pull request. We should do our best to avoid this pattern. Since this changes the `main` branch, there will be a new tagged release.
+
+We try to follow the principles set out in [Git Flow](https://nvie.com/posts/a-successful-git-branching-model/) with a few modifications:
+
+  - We use the `main` branch instead of the `master` branch, and we use the `dev` branch instead of the `develop` branch.
+  - We don’t use release branches, we create release tags from the `main` branch. Therefore we shouldn’t use the `release-` prefix at all.
+
+Every project should have a `main` branch which contains the most stable version of the software, or the version of the software that corresponds to the most recent release of the software.
+
+[**Prototype**](#statuses) status projects must have all of the above and the following:
+
+  - At least two but no more than three designated project leads (specified in the [CODEOWNERS file][codeowners]).
+  - `main` branch protections such that `main` can only be updated by a pull request from `dev` or a branch that begins with `hotfix-`, and a review from at least one project lead.
+
+[**Stable**](#statuses) status projects must have all of the above and the following:
+
+  - Code releases that correspond to specific git tags.
+
 ## Package releases {#sec-releases}
 
 In general follow the [Releasing to CRAN chapter](https://r-pkgs.org/release.html) in the book [R Packages][rpkgs] for R, and the [Releasing and versioning chapter](https://py-pkgs.org/07-releasing-versioning) in the book [Python Packages][pypkgs] for Python. Those chapters don't have to be followed to the letter, but in general they provide really good guidance.
 
 There are a few aspects of releases we are opinionated about and would like all WILDS R and Python packages to follow:
 
-- Use the MIT license unless there's good reason not to
-- Follow our versioning guidelines above
-- Git tag released versions, and push the tag to GitHub
-- Add the associated NEWS/Changelog items to a release associated with the tag on GitHub
+- Follow our versioning guidelines above (@sec-versioning).
+- Every merge from `dev` into `main` should constitute a release, which should generate a tagged version of the software and an increment to the version number.
+- Every time the version number is incremented, the `NEWS.md` file should be updated describing what changes to the software have been made in the new version.
+- If a software package is distributed on an archive like CRAN or PyPI, wait to update the main branch until that software has been accepted by the archive.
+- How we create tagged releases on GitHub:
+    - The tag itself should be called `v[Version Number]` (like `v0.1.0` or `v2.4.1`).
+    - Describe each update and change in the release in a bullet point.
+    - To the greatest extent possible, link each update or change to an issue, pull request, and to the developers that led the implementation.
+    - See <https://github.com/getwilds/proof/releases/tag/v1.0> for a great example of how to structure a release.
 
 
 [rpkgs]: https://r-pkgs.org
@@ -85,3 +130,4 @@ There are a few aspects of releases we are opinionated about and would like all 
 [lifecycle]: https://r-pkgs.org/lifecycle.html
 [funcx]:https://r-pkgs.org/lifecycle.html#sec-lifecycle-stages-and-package
 [mit]: https://choosealicense.com/licenses/mit/
+[codeowners]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/packagedocs.qmd
+++ b/packagedocs.qmd
@@ -34,9 +34,18 @@ For either of the options above, they can be hosted in many places, including [G
 
 ## Guidelines
 
-- README: This is most likely the first place potential users will interact with your package. Make sure the README clearly states what the package does, and how to get started.
+- README:
+  - All repositories must have a README.md file.
+  - All repositories must have a project status badge (see below for badge specific guidelines).
+  - This is most likely the first place potential users will interact with your package. Make sure the README clearly states what the package does, and how to get started.
 - Examples: All user facing functions should have examples. Make sure to be careful about how examples are run if there's any sensitive data or connections to remote services.
 - Vignettes: From the [R Packages book](https://r-pkgs.org/vignettes.html): "A vignette is a long-form guide to your package. Function documentation is great if you know the name of the function you need, but it’s useless otherwise. In contrast, a vignette can be framed around a target problem that your package is designed to solve. The vignette format is perfect for showing a workflow that solves that particular problem, start to finish. Vignettes afford you different opportunities than help topics: you have much more control over the integration of code and prose and it’s a better setting for showing how multiple functions work together."
+
+Badge specific guidelines
+
+- [**Experimental**](#statuses) status projects should have a README that describes what the software does and how to install it. At the Experimental level and above, all functions should have accompanying docstrings (in the case of Python), roxygen2 comments (in the case of R), or equivalent function-level documentation. See Google’s style guide on [Python docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) and the R Packages chapter on [function documentation](https://r-pkgs.org/man.html).
+- [**Prototype**](#statuses) status projects should have all of the above and a README that contains examples of how to use the software.
+- [**Stable**](#statuses) status projects should have all the above and mature, fully-featured READMEs with badges for automated testing outcomes and software repository availability. They should also feature detailed information about who the software is intended for, how it’s intended to be used, with fully-worked examples of how to install and use the software. Stable status projects should also have a standalone website that contains more detailed information about the software.
 
 
 [pkgdown]: https://pkgdown.r-lib.org/

--- a/testing.qmd
+++ b/testing.qmd
@@ -1,0 +1,12 @@
+# Testing {{< iconify fa6-solid bug >}} {#sec-testing}
+
+- All [**Stable**](#statuses) projects need automated software testing set up via GitHub Actions with a status badge in the README.md
+- Software that interacts with the internet should use the [vcr][] or [webmockr][] package for testing whenever possible and appropriate.
+- When writing a test suite, you should aspire to as much [code coverage](https://en.wikipedia.org/wiki/Code_coverage) as is appropriate, although usually higher code coverage is better. When thinking about code coverage, consider this blog post from Google Engineering [
+Code Coverage Best Practices](https://testing.googleblog.com/2020/08/code-coverage-best-practices.html) and the [advice of the ancient master Testivus](https://www.artima.com/forums/flat.jsp?forum=106&thread=204677).
+- Whenever possible use a well established testing framework like [pytest][] for Python, or [testthat][] for R.
+
+[vcr]: https://docs.ropensci.org/vcr
+[webmockr]: https://docs.ropensci.org/webmockr
+[pytest]: https://docs.pytest.org
+[testthat]: https://testthat.r-lib.org/


### PR DESCRIPTION
fixes #34 

I've attempted feathering in the SDLC best practices content here into the guide. Do suggest different approaches if you think other things would work better. 

Notes on each section from the SDLC best practices document:

- Software Project Status and Practice Overview: inserted into this section https://deploy-preview-35--monumental-cassata-2f9bb7.netlify.app/conventions#statuses Seem okay? Or a better place?
- Versioning: put into the versioning section in the Package Maintenance chapter https://deploy-preview-35--monumental-cassata-2f9bb7.netlify.app/maintenance#sec-versioning Seem okay?
- Branching: put into a new branching section in the Package Maintenance chapter https://deploy-preview-35--monumental-cassata-2f9bb7.netlify.app/maintenance#branching Seem okay?
- Code Review: folded into the DaSL Internal section https://deploy-preview-35--monumental-cassata-2f9bb7.netlify.app/codereview-dasl#high-level-approach Seem okay?
- Testing: added new testing chapter https://deploy-preview-35--monumental-cassata-2f9bb7.netlify.app/testing Seem good?
- Documentation: added to the Guidelines section of the Documentation chapter https://deploy-preview-35--monumental-cassata-2f9bb7.netlify.app/packagedocs#guidelines Seem good?
- Releases: weaved into the extant Package releases section of the Package maintenance chapter https://deploy-preview-35--monumental-cassata-2f9bb7.netlify.app/maintenance#sec-releases Good?

I've added a new section listing the badges and their statuses https://deploy-preview-35--monumental-cassata-2f9bb7.netlify.app/conventions#statuses - Idea then being to link to this section whenever we mention a status type so that readers can click through to understand what e.g., Experimental means