### PR TITLE
add additional info for adding fred hutch as fnd

### DIFF
--- a/conventions.qmd
+++ b/conventions.qmd
@@ -6,21 +6,55 @@
 
 The following are examples for R and Python:
 
-- R:
-  - With the `usethis` package you can add an entry of type `person` to the DESCRIPTION file of your package
+### R
 
-  ```r
-  usethis::use_author("Fred Hutchinson Cancer Center", role = "fnd", email = "wilds@fredhutch.org")
-  ```
-- Python:
-  - Add a dict in the authors block of the pyproject.toml file or other config file in your package
+Use the `usethis` package to add an entry of type `person` to the DESCRIPTION file of your package
 
-  ```python3
-  {
-    name = "Fred Hutchinson Cancer Center"",
-    email = "wilds@fredhutch.org"
-  }
-  ```
+```r
+# install.packages("pak")
+pak::pak("usethis")
+usethis::use_author("Fred Hutchinson Cancer Center", role = "fnd", email = "wilds@fredhutch.org")
+```
+
+And use the `desc` package to add a Research Organization (ROR) identifier for Fred Hutch
+
+```r
+# `desc` version 1.4.3.9000 or greater for function `desc_add_ror`
+pak::pak("r-lib/desc")
+desc::desc_add_ror(ror = "007ps6h72", given = "Fred Hutchinson Cancer Center")
+```
+
+Which should give you in your `DESCRIPTION` file:
+
+
+> person("Fred Hutchinson Cancer Center", , , "wilds@fredhutch.org",
+    role = "fnd", comment = c(ROR = "007ps6h72"))
+
+
+### Python
+
+Add a dict in the authors block of the pyproject.toml file in your package:
+
+```toml
+authors = [
+    {
+        name = "Fred Hutchinson Cancer Center",
+        email = "wilds@fredhutch.org"
+    }
+]
+```
+
+Then add the ROR identifier as:
+
+```toml
+[tool.package-name.metadata]
+authors = [
+    {
+        name = "Fred Hutchinson Cancer Center",
+        ror = "007ps6h72"
+    }
+]
+```
 
 For other types of WILDS repositories, perhaps just add a mention to the README.
 


### PR DESCRIPTION
In working on https://github.com/getwilds/sixtyfour/pull/115 noticed that we do not have instructions in our guide on adding FH as funder to R and Python pkgs. So this PR adds that. 

R
- need a dev version of `desc` package - there's a [new fxn to add ROR](https://github.com/r-lib/desc/pull/159/files) to `person` object -`usethis::use_author` doesn't have a way of adding a ROR (or ORCID, etc.)

Python
- There's no formal way to have roles in python pkgs like we have in R - see https://discuss.python.org/t/the-author-maintainer-distinction-problem-and-pep-621/4562/14 
- There's no formal way to add extra metadata to authors like ROR or ORCID. What I settled on was https://discuss.python.org/t/adding-extra-fields-in-the-pyproject-toml-authors-maintainers-list/16848/3 mentioned adding metadata to a `tool.` field and here's an example of that in the sourmash project https://github.com/sourmash-bio/sourmash/blob/fbadc594dd1ec98a39064636d1bf3ae826b7b6da/pyproject.toml#L93 